### PR TITLE
[fix bug 1184718] Default browser snippet

### DIFF
--- a/templates/windows-10/default-browser.html
+++ b/templates/windows-10/default-browser.html
@@ -4,7 +4,7 @@
 <div class="snippet" id="{{ snippet_id }}-fx-default">
     <div>
       <a href="#" class="launch-default"><img class="icon" id="{{ snippet_id }}-icon"/></a>
-      <div id="{{ snippet_id }}-text"></div>
+      <p id="{{ snippet_id }}-text"></p>
     </div>
 
     <script type="text/javascript">
@@ -17,31 +17,30 @@
           var snippet_text = document.getElementById('{{ snippet_id }}-text');
           var snippet_icon = document.getElementById('{{ snippet_id }}-icon');
           var poll_retry = 0;
-          var check_default_timeout;
-          var last_check;
+          var check_default_timeout = undefined;
+          var is_firefox_default = undefined;
           var cta_clicked = false;
 
           isDefault(function yesDefault () {
             sendMetric('impression-is-default');
             showDefaultContent();
-            last_check = true;
+            is_firefox_default = true;
           }, function noDefault () {
             sendMetric('impression-is-not-default');
             showNonDefaultContent();
-            last_check = false;
+            is_firefox_default = false;
           });
 
           var check_default_timeout = window.setInterval(function () {
             if (poll_retry > 500) {
               clearInterval(check_default_timeout);
             }
-            poll_retry ++;
+            poll_retry++;
             isDefault(function yesDefault () {
               //Default has switched while the snippet is opened
-              if (last_check !== true) {
-                showDefaultContent();
-                snippet_text.innerHTML = "<p>{{ text_default_success|safe }}</p>";
-                last_check = true;
+              if (is_firefox_default !== true) {
+                showSuccessContent();
+                is_firefox_default = true;
                 if (cta_clicked === true) {
                   sendMetric('conversion-is-default-changed-after-click');
                 } else {
@@ -50,15 +49,29 @@
                 clearInterval(check_default_timeout);
               }
             }, function noDefault () {
-              if (last_check !== false) {
+              if (is_firefox_default !== false) {
                 showNonDefaultContent();
-                last_check = false;
+                is_firefox_default = false;
               }
             });
-          }, 2000);
+          }, 1000);
 
           function showDefaultContent () {
-              snippet_text.innerHTML = "<p>{{ text_default|safe }}</p>";
+              snippet_text.innerHTML = "{{ text_default|safe }}";
+              snippet_icon.src = "{{ icon_default }}";
+
+              for (var i=0; i < buttons.length; i++) {
+                buttons[i].addEventListener('click', function (e) {
+                  e.preventDefault();
+                  sendMetric('conversion-is-default-click', function () {
+                    window.location = '{{ url_default|safe }}';
+                  });
+                }, false);
+              }
+          }
+
+          function showSuccessContent () {
+              snippet_text.innerHTML = "{{ text_default_success|safe }}";
               snippet_icon.src = "{{ icon_default }}";
 
               for (var i=0; i < buttons.length; i++) {
@@ -72,7 +85,7 @@
           }
 
           function showNonDefaultContent () {
-              snippet_text.innerHTML = "<p>{{ text_not_default|safe }}</p>";
+              snippet_text.innerHTML = "{{ text_not_default|safe }}";
               snippet_icon.src = "{{ icon_not_default }}";
 
               for (var i=0; i < buttons.length; i++) {

--- a/templates/windows-10/default-browser.html
+++ b/templates/windows-10/default-browser.html
@@ -1,0 +1,128 @@
+<!-- Any instances of {{ snippet_id }} are replaced with the ID number for the
+     snippet using this template. -->
+
+<div class="snippet" id="{{ snippet_id }}-fx-default">
+    <div id="{{ snippet_id }}-content"></div>
+
+    <script type="text/javascript">
+      //<![CDATA[
+
+      (function() {
+        var snippet = document.getElementById('{{ snippet_id }}-fx-default');
+        snippet.addEventListener('show_snippet', function () {
+          var buttons = snippet.getElementsByClassName('launch-default');
+          var snippet_content = document.getElementById('{{ snippet_id }}-content');
+
+          isDefault('appinfo', function yesDefault () {
+            sendMetric('impression-is-default');
+            snippet_content.innerHTML = '<a href="#" class="launch-default"><img class="icon" src="{{ icon_default }}" /></a><p>{{ text_default|escape }}</p>';
+
+            for (var i=0; i < buttons.length; i++) {
+              buttons[i].addEventListener('click', function (e) {
+                e.preventDefault();
+                sendMetric('conversion-is-default-click', function () {
+                  window.location = '{{ url_default|safe }}';
+                });
+              }, false);
+            }
+          }, function noDefault () {
+            sendMetric('impression-is-not-default');
+            snippet_content.innerHTML = '<a href="#" class="launch-default"><img class="icon" src="{{ icon_default }}" /></a><p>{{ text_not_default|escape }}</p>';
+
+            for (var i=0; i < buttons.length; i++) {
+              buttons[i].addEventListener('click', function (e) {
+                e.preventDefault();
+                Mozilla.UITour.setConfiguration('defaultBrowser');
+                sendMetric('conversion-is-not-default-click');
+              }, false);
+            }
+          });
+        }, false);
+
+        // create namespace
+        if (typeof Mozilla == 'undefined') {
+          var Mozilla = {};
+        }
+
+        'use strict';
+
+        // create namespace
+        if (typeof Mozilla.UITour == 'undefined') {
+          Mozilla.UITour = {};
+        }
+
+        var notificationListener = null;
+
+        function _notificationListener (event) {
+          if (typeof event.detail != 'object')
+            return;
+          if (typeof notificationListener != 'function')
+            return;
+
+          notificationListener(event.detail.event, event.detail.params);
+        }
+
+        function _sendEvent (action, data) {
+          var event = new CustomEvent('mozUITour', {
+            bubbles: true,
+            detail: {
+              action: action,
+              data: data || {}
+            }
+          });
+
+          document.dispatchEvent(event);
+        }
+
+        function _generateCallbackID () {
+          return Math.random().toString(36).replace(/[^a-z]+/g, '');
+        }
+
+        function _waitForCallback (callback) {
+          var id = _generateCallbackID();
+
+          function listener (event) {
+            if (typeof event.detail != 'object')
+              return;
+            if (event.detail.callbackID != id)
+              return;
+
+            document.removeEventListener('mozUITourResponse', listener);
+            callback(event.detail.data);
+          }
+          document.addEventListener('mozUITourResponse', listener);
+
+          return id;
+        }
+
+        Mozilla.UITour.getConfiguration = function(configName, callback) {
+          _sendEvent('getConfiguration', {
+            callbackID: _waitForCallback(callback),
+            configuration: configName,
+          });
+        };
+
+        Mozilla.UITour.setConfiguration = function(configName, configValue) {
+            _sendEvent('setConfiguration', {
+                configuration: configName,
+                value: configValue
+            });
+        };
+
+        function isDefault(target, yesDefault, noDefault) {
+          Mozilla.UITour.getConfiguration(target, function(config) {
+              if (config && config.defaultBrowser === true) {
+                  yesDefault();
+              } else if (config && config.defaultBrowser === false) {
+                  noDefault();
+              } else {
+                  yesDefault();
+              }
+          });
+        }
+        
+      })();
+
+      //]]>
+  </script>
+</div>

--- a/templates/windows-10/default-browser.html
+++ b/templates/windows-10/default-browser.html
@@ -2,7 +2,10 @@
      snippet using this template. -->
 
 <div class="snippet" id="{{ snippet_id }}-fx-default">
-    <div id="{{ snippet_id }}-content"></div>
+    <div>
+      <a href="#" class="launch-default"><img class="icon" id="{{ snippet_id }}-icon"/></a>
+      <div id="{{ snippet_id }}-text"></div>
+    </div>
 
     <script type="text/javascript">
       //<![CDATA[
@@ -11,32 +14,77 @@
         var snippet = document.getElementById('{{ snippet_id }}-fx-default');
         snippet.addEventListener('show_snippet', function () {
           var buttons = snippet.getElementsByClassName('launch-default');
-          var snippet_content = document.getElementById('{{ snippet_id }}-content');
+          var snippet_text = document.getElementById('{{ snippet_id }}-text');
+          var snippet_icon = document.getElementById('{{ snippet_id }}-icon');
+          var poll_retry = 0;
+          var check_default_timeout;
+          var last_check;
+          var cta_clicked = false;
 
-          isDefault('appinfo', function yesDefault () {
+          isDefault(function yesDefault () {
             sendMetric('impression-is-default');
-            snippet_content.innerHTML = '<a href="#" class="launch-default"><img class="icon" src="{{ icon_default }}" /></a><p>{{ text_default|escape }}</p>';
-
-            for (var i=0; i < buttons.length; i++) {
-              buttons[i].addEventListener('click', function (e) {
-                e.preventDefault();
-                sendMetric('conversion-is-default-click', function () {
-                  window.location = '{{ url_default|safe }}';
-                });
-              }, false);
-            }
+            showDefaultContent();
+            last_check = true;
           }, function noDefault () {
             sendMetric('impression-is-not-default');
-            snippet_content.innerHTML = '<a href="#" class="launch-default"><img class="icon" src="{{ icon_default }}" /></a><p>{{ text_not_default|escape }}</p>';
-
-            for (var i=0; i < buttons.length; i++) {
-              buttons[i].addEventListener('click', function (e) {
-                e.preventDefault();
-                Mozilla.UITour.setConfiguration('defaultBrowser');
-                sendMetric('conversion-is-not-default-click');
-              }, false);
-            }
+            showNonDefaultContent();
+            last_check = false;
           });
+
+          var check_default_timeout = window.setInterval(function () {
+            if (poll_retry > 500) {
+              clearInterval(check_default_timeout);
+            }
+            poll_retry ++;
+            isDefault(function yesDefault () {
+              //Default has switched while the snippet is opened
+              if (last_check !== true) {
+                showDefaultContent();
+                snippet_text.innerHTML = "<p>{{ text_default_success|safe }}</p>";
+                last_check = true;
+                if (cta_clicked === true) {
+                  sendMetric('conversion-is-default-changed-after-click');
+                } else {
+                  sendMetric('conversion-is-default-changed-without-click');
+                }
+                clearInterval(check_default_timeout);
+              }
+            }, function noDefault () {
+              if (last_check !== false) {
+                showNonDefaultContent();
+                last_check = false;
+              }
+            });
+          }, 2000);
+
+          function showDefaultContent () {
+              snippet_text.innerHTML = "<p>{{ text_default|safe }}</p>";
+              snippet_icon.src = "{{ icon_default }}";
+
+              for (var i=0; i < buttons.length; i++) {
+                buttons[i].addEventListener('click', function (e) {
+                  e.preventDefault();
+                  sendMetric('conversion-is-default-click', function () {
+                    window.location = '{{ url_default|safe }}';
+                  });
+                }, false);
+              }
+          }
+
+          function showNonDefaultContent () {
+              snippet_text.innerHTML = "<p>{{ text_not_default|safe }}</p>";
+              snippet_icon.src = "{{ icon_not_default }}";
+
+              for (var i=0; i < buttons.length; i++) {
+                buttons[i].addEventListener('click', function (e) {
+                  e.preventDefault();
+                  Mozilla.UITour.setConfiguration('defaultBrowser');
+                  sendMetric('conversion-is-not-default-click');
+                  cta_clicked = true;
+                }, false);
+              }    
+          }
+
         }, false);
 
         // create namespace
@@ -109,8 +157,8 @@
             });
         };
 
-        function isDefault(target, yesDefault, noDefault) {
-          Mozilla.UITour.getConfiguration(target, function(config) {
+        function isDefault (yesDefault, noDefault) {
+          Mozilla.UITour.getConfiguration('appinfo', function(config) {
               if (config && config.defaultBrowser === true) {
                   yesDefault();
               } else if (config && config.defaultBrowser === false) {

--- a/templates/windows-10/default-browser.html
+++ b/templates/windows-10/default-browser.html
@@ -4,7 +4,9 @@
 <div class="snippet" id="{{ snippet_id }}-fx-default">
     <div>
       <a href="#" class="launch-default"><img class="icon" id="{{ snippet_id }}-icon"/></a>
-      <p id="{{ snippet_id }}-text"></p>
+      <p id="{{ snippet_id }}-text-default" style="display:none;">{{ text_default|safe }}</p>
+      <p id="{{ snippet_id }}-text-not-default" style="display:none;">{{ text_not_default|safe }}</p>
+      <p id="{{ snippet_id }}-text-success" style="display:none;">{{ text_default_success|safe }}</p>
     </div>
 
     <script type="text/javascript">
@@ -14,7 +16,9 @@
         var snippet = document.getElementById('{{ snippet_id }}-fx-default');
         snippet.addEventListener('show_snippet', function () {
           var buttons = snippet.getElementsByClassName('launch-default');
-          var snippet_text = document.getElementById('{{ snippet_id }}-text');
+          var snippet_text_default = document.getElementById('{{ snippet_id }}-text-default');
+          var snippet_text_not_default = document.getElementById('{{ snippet_id }}-text-not-default');
+          var snippet_text_success = document.getElementById('{{ snippet_id }}-text-success');
           var snippet_icon = document.getElementById('{{ snippet_id }}-icon');
           var poll_retry = 0;
           var check_default_timeout = undefined;
@@ -57,7 +61,10 @@
           }, 1000);
 
           function showDefaultContent () {
-              snippet_text.innerHTML = "{{ text_default|safe }}";
+              snippet_text_default.style.display = 'block';
+              snippet_text_not_default.style.display = 'none';
+              snippet_text_success.style.display = 'none';
+
               snippet_icon.src = "{{ icon_default }}";
 
               for (var i=0; i < buttons.length; i++) {
@@ -71,7 +78,10 @@
           }
 
           function showSuccessContent () {
-              snippet_text.innerHTML = "{{ text_default_success|safe }}";
+              snippet_text_default.style.display = 'none';
+              snippet_text_not_default.style.display = 'none';
+              snippet_text_success.style.display = 'block';
+
               snippet_icon.src = "{{ icon_default }}";
 
               for (var i=0; i < buttons.length; i++) {
@@ -85,7 +95,10 @@
           }
 
           function showNonDefaultContent () {
-              snippet_text.innerHTML = "{{ text_not_default|safe }}";
+              snippet_text_default.style.display='none';
+              snippet_text_not_default.style.display='block';
+              snippet_text_success.style.display='none';
+
               snippet_icon.src = "{{ icon_not_default }}";
 
               for (var i=0; i < buttons.length; i++) {


### PR DESCRIPTION
@glogiotatidis r?

Notes:

- Targets for this snippet will be Firefox 40 (e.g. nightly/beta) on Windows 10.
- If you don't have a VM, the action will be similar on Mac/Windows <10.
- Since there is UITour involved, you'll have to update `browser.uitour.testingOrigins` accordingly.
- Depending on whether or not Firefox is your default browser, you will see different actions (see template field descriptions).
- Note: some of the creative may change slightly (e.g. adding a larger CTA), but I wanted to see if you'd check some of the functional bits before you take leave.

Thanks Giorgos!