### PR TITLE
[bug 1225997] Fix some icon alignment and video alignment

### DIFF
--- a/generic-templates/video-snippets/simple-over-search-bar.html
+++ b/generic-templates/video-snippets/simple-over-search-bar.html
@@ -47,7 +47,7 @@
 #logo-replacement-{{ snippet_id }} .video-container {
     width: 480px;
     position: absolute;
-    left: 90px;
+    left: 84px;
     top: 15px;
 }
 
@@ -96,7 +96,7 @@
     display: block;
     color: #FFF;
     cursor: pointer;
-    line-height: 100px;
+    line-height: 94px;
     font-size: 42px;
     text-align: center;
     margin: 0 auto 20px;


### PR DESCRIPTION
Fix some minor icon and video alignment issues.

Also, what is the best way to get the three videos attached to the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1226356) uploaded to the Snippet CDN?

@glogiotatidis r?

Sample: https://snippets.allizom.org/show/85/

Here it is working on about:home using snippet switcher
http://cl.ly/image/3J1j3F2R2j1V
http://cl.ly/image/2z1Z0p14173C